### PR TITLE
Renaming pymc.sample_ppc function to sample_posterior_predictive. Based on https://github.com/pymc-devs/pymc/issues/3037

### DIFF
--- a/pymc3_models/models/LinearRegression.py
+++ b/pymc3_models/models/LinearRegression.py
@@ -142,7 +142,7 @@ class LinearRegression(BayesianModel):
 
         self._set_shared_vars({'model_input': X, 'model_output': np.zeros(num_samples)})
 
-        ppc = pm.sample_ppc(self.trace, model=self.cached_model, samples=num_ppc_samples)
+        ppc = pm.sample_posterior_predictive(self.trace, model=self.cached_model, samples=num_ppc_samples)
 
         if return_std:
             return ppc['y'].mean(axis=0), ppc['y'].std(axis=0)


### PR DESCRIPTION
Pull Request Checklist
 - [x] Linter passes locally
 - [x] All tests in the `tests` folder pass with a local build
 - [x] CHANGELOG has been updated
 - [x] Version in `_version.py` has been updated
 - [x] README has been updated (if applicable)